### PR TITLE
Get docker-compose working out of the box

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,28 @@
 version: '3'
 
 services:
+    nginx:
+        restart: always
+        image: nginx:1.11.6-alpine
+        ports:
+            - 8000:8000
+        volumes:
+            - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+            - ./django
     mongo:
         restart: always
         image: mongo:4.0.0
-        expose:
-            - 27017
-        ports:
-            - 27017:27017
-        volumes:
-          - ./docker/mongo/data:/data/db
-    rabbitmq:
+    backend:
         restart: always
-        image: rabbitmq:alpine
-        hostname: "wtc-rabbit"
-        expose:
-            - 5672
-        ports:
-            - 5672:5672
+        build:
+            context: .
+            dockerfile: ./docker/django/Dockerfile
         volumes:
-          - ./docker/rabbitmq/data:/var/lib/rabbitmq/mnesia
+            - .:/django
+        links:
+            - mongo
+        entrypoint:
+            - /django-entrypoint.sh
     frontend:
         restart: always
         build:
@@ -27,6 +30,11 @@ services:
             dockerfile: ./docker/web/Dockerfile
         volumes:
             - .:/django
+        links:
+            - backend
         entrypoint:
             - /web-entrypoint.sh
-        network_mode: "host"
+    rabbitmq:
+        restart: always
+        image: rabbitmq:alpine
+        hostname: "wtc-rabbit"

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -1,5 +1,5 @@
-#FROM python:3.4.3
-FROM container-registry.oracle.com/database/instantclient:12.2.0.1
+FROM python:3.4.3
+#FROM container-registry.oracle.com/database/instantclient:12.2.0.1
 
 RUN python -V
 
@@ -7,7 +7,7 @@ ENV PYTHONUNBUFFERED 1
 
 COPY ./docker/django/django-entrypoint.sh /
 COPY ./py-requirements /django/py-requirements
-COPY ./oracle-admin /
+#COPY ./oracle-admin /
 
 WORKDIR /django
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.4.3
-#FROM container-registry.oracle.com/database/instantclient:12.2.0.1
 
 RUN python -V
 
@@ -7,7 +6,6 @@ ENV PYTHONUNBUFFERED 1
 
 COPY ./docker/django/django-entrypoint.sh /
 COPY ./py-requirements /django/py-requirements
-#COPY ./oracle-admin /
 
 WORKDIR /django
 

--- a/src/djangoreactredux/settings/dev_docker.py
+++ b/src/djangoreactredux/settings/dev_docker.py
@@ -1,26 +1,63 @@
 import mongoengine
 
-from djangoreactredux.settings.dev import *  # NOQA (ignore all errors on this line)
-from djangoreactredux.settings.local import *
+from djangoreactredux.settings.base import *
+
+DEBUG = True
+
+PAGE_CACHE_SECONDS = 1
 
 DATABASES = {
     'default': {
         'ENGINE': '',
     },
-    'unified': UNIFIED_DB,
-}
-
-MONGODB_DATABASES = {
-    'default': {
-        'NAME': 'wtc-console',
-        'HOST': 'mongo',
-        'PORT': 8081,
-        'USER': 'root',
-        'PASSWORD': 'root',
+    'unified': {
+        'ENGINE': '',
     }
 }
 
 mongoengine.connect(
-    db=MONGODB_DATABASES['default']['NAME'],
-    host=MONGODB_DATABASES['default']['HOST']
+    db='wtc-console',
+    host='mongo'
 )
+
+REST_FRAMEWORK['EXCEPTION_HANDLER'] = 'django_rest_logger.handlers.rest_exception_handler'  # NOQA (ignore all errors on this line)
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'root': {
+        'level': 'DEBUG',
+        'handlers': ['django_rest_logger_handler'],
+    },
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s '
+                      '%(process)d %(thread)d %(message)s'
+        },
+    },
+    'handlers': {
+        'django_rest_logger_handler': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
+        }
+    },
+    'loggers': {
+        'django.db.backends': {
+            'level': 'ERROR',
+            'handlers': ['django_rest_logger_handler'],
+            'propagate': False,
+        },
+        'django_rest_logger': {
+            'level': 'DEBUG',
+            'handlers': ['django_rest_logger_handler'],
+            'propagate': False,
+        },
+    },
+}
+
+DEFAULT_LOGGER = 'django_rest_logger'
+
+LOGGER_EXCEPTION = DEFAULT_LOGGER
+LOGGER_ERROR = DEFAULT_LOGGER
+LOGGER_WARNING = DEFAULT_LOGGER


### PR DESCRIPTION
`docker-compose up` works from the root directory. I can now get a blank page showing served from my http://localhost:8000.

Still need to fill the workflows with some useful data to show things we can play with. `python manage.py dumpdata` should basically do the trick, but haven't been able to get one of the running servers to cooperate yet.