### PR TITLE
Load data into MongoDB to display workflows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
             - ./django
     mongo:
         restart: always
-        image: mongo:4.0.0
+        build:
+            context: ./docker/mongo
+        volumes:
+            - ./docker/mongo:/to_restore
     backend:
         restart: always
         build:
@@ -34,7 +37,3 @@ services:
             - backend
         entrypoint:
             - /web-entrypoint.sh
-    rabbitmq:
-        restart: always
-        image: rabbitmq:alpine
-        hostname: "wtc-rabbit"

--- a/docker/mongo/Dockerfile
+++ b/docker/mongo/Dockerfile
@@ -1,0 +1,3 @@
+FROM mongo:4.0.0
+
+COPY ./setup.sh /docker-entrypoint-initdb.d

--- a/docker/mongo/setup.sh
+++ b/docker/mongo/setup.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+tar -xf /to_restore/wtc_console_dev.tar.gz
+mongorestore -d wtc-console /wtc_console_dev


### PR DESCRIPTION
@vargasa It turns out that `mongodump` is easier to import than `mongoexport`, so I went back and dumped the wtc-console-dev database. This seems to be showing workflows now.

I took out rabbitmq because it doesn't seem to be used in this case. It's for the Celery workers, right?