### PR TITLE
Expose mongo port for local debugging. Reduce query flexibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
             - ./django
     mongo:
         restart: always
+        ports:
+            - 27017:27017
         image: dabercro/wtc-dev-mongo:190422
     backend:
         restart: always

--- a/src/workflows/views.py
+++ b/src/workflows/views.py
@@ -38,9 +38,6 @@ class TaskViewSet(viewsets.ReadOnlyModelViewSet):
         if filter_query:
             tasks = tasks.filter(
                 Q(name__icontains=filter_query)
-                | Q(campaign__icontains=filter_query)
-                | Q(workflows__name__icontains=filter_query)
-                | Q(workflows__tasks__name__icontains=filter_query)
             )
 
         page = self.paginate_queryset(tasks)


### PR DESCRIPTION
- **Expose Mongo port for local debugging**: I don't think we plan on using `docker-compose` in production anywhere
- **Reduce query flexibility**: It is a nasty hack for now, but we want to be able to quickly present an interface that the P&R team can use to find workflows without duplicates. For now, let's just allow queries by PrepID.
